### PR TITLE
Rotation

### DIFF
--- a/leftwm-layouts/src/geometry/mod.rs
+++ b/leftwm-layouts/src/geometry/mod.rs
@@ -7,10 +7,10 @@ mod rotation;
 mod size;
 mod split_axis;
 
-pub use calc::{divrem, flip, remainderless_division, split, rotate};
+pub use calc::{divrem, flip, remainderless_division, rotate, split};
 pub use column_type::ColumnType;
 pub use flipped::Flipped;
-pub use rect::Rect;
+pub use rect::{FloatRect, Rect};
 pub use reserve_space::ReserveColumnSpace;
 pub use rotation::Rotation;
 pub use size::Size;

--- a/leftwm-layouts/src/geometry/rect.rs
+++ b/leftwm-layouts/src/geometry/rect.rs
@@ -1,4 +1,4 @@
-/// Represents a rectangle with a position ([`Rect::x`], [`Rect::y`])
+//, rects[i].y/ Represents a rectangle with a position ([`Rect::x`], [`Rect::y`])
 /// and dimensions ([`Rect::w`], [`Rect::h`]).
 ///
 /// ## Demonstration
@@ -47,6 +47,9 @@ impl Rect {
         (x, y)
     }
 
+    /// Check whether a point is contained in a `Rect`.
+    ///
+    /// The boundary counts as part of the `Rect`.
     pub fn contains(&self, point: (i32, i32)) -> bool {
         self.x <= point.0
             && point.0 <= self.x + self.w as i32
@@ -133,5 +136,27 @@ mod tests {
     fn center_calculation_at_rounded_position() {
         let rect = Rect::new(100, 100, 387, 399);
         assert_eq!(rect.center(), (294, 300))
+    }
+
+    #[test]
+    fn contains_boundary() {
+        let rect = Rect::new(100, 100, 400, 100);
+        assert!(rect.contains((100, 100)));
+        assert!(rect.contains((500, 100)));
+        assert!(rect.contains((500, 200)));
+        assert!(rect.contains((100, 200)));
+    }
+
+    #[test]
+    fn does_not_contain_points_outside_rect() {
+        let rect = Rect::new(100, 100, 400, 100);
+        assert!(!rect.contains((99, 100)));
+        assert!(!rect.contains((501, 100)));
+        assert!(!rect.contains((501, 200)));
+        assert!(!rect.contains((99, 200)));
+        assert!(!rect.contains((100, 99)));
+        assert!(!rect.contains((500, 99)));
+        assert!(!rect.contains((500, 201)));
+        assert!(!rect.contains((100, 201)));
     }
 }

--- a/leftwm-layouts/src/geometry/rect.rs
+++ b/leftwm-layouts/src/geometry/rect.rs
@@ -1,4 +1,4 @@
-//, rects[i].y/ Represents a rectangle with a position ([`Rect::x`], [`Rect::y`])
+/// Represents a rectangle with a position ([`Rect::x`], [`Rect::y`])
 /// and dimensions ([`Rect::w`], [`Rect::h`]).
 ///
 /// ## Demonstration
@@ -69,6 +69,9 @@ impl Default for Rect {
     }
 }
 
+/// Similar to `Rect`, but with less functionality
+///
+/// Intended to perform operations that require rounding afterwards, e.g. rotation.
 pub struct FloatRect {
     pub x: f32,
     pub y: f32,

--- a/leftwm-layouts/src/geometry/rect.rs
+++ b/leftwm-layouts/src/geometry/rect.rs
@@ -46,6 +46,13 @@ impl Rect {
         let y = self.y + (self.h as f32 / 2.0).round() as i32;
         (x, y)
     }
+
+    pub fn contains(&self, point: (i32, i32)) -> bool {
+        self.x <= point.0
+            && point.0 <= self.x + self.w as i32
+            && self.y <= point.1
+            && point.1 <= self.y + self.h as i32
+    }
 }
 
 impl Default for Rect {
@@ -55,6 +62,41 @@ impl Default for Rect {
             y: 0,
             w: 500,
             h: 250,
+        }
+    }
+}
+
+pub struct FloatRect {
+    pub x: f32,
+    pub y: f32,
+    pub w: f32,
+    pub h: f32,
+}
+
+impl FloatRect {
+    pub fn new(x: f32, y: f32, w: f32, h: f32) -> Self {
+        Self { x, y, w, h }
+    }
+}
+
+impl From<&Rect> for FloatRect {
+    fn from(rect: &Rect) -> FloatRect {
+        FloatRect {
+            x: rect.x as f32,
+            y: rect.y as f32,
+            w: rect.w as f32,
+            h: rect.h as f32,
+        }
+    }
+}
+
+impl From<&FloatRect> for Rect {
+    fn from(rect: &FloatRect) -> Rect {
+        Rect {
+            x: rect.x as i32,
+            y: rect.y as i32,
+            w: rect.w as u32,
+            h: rect.h as u32,
         }
     }
 }

--- a/leftwm-layouts/src/geometry/rotation.rs
+++ b/leftwm-layouts/src/geometry/rotation.rs
@@ -72,9 +72,9 @@ impl Rotation {
     /// the Rect's anchor after it is rotated.
     ///
     /// ## Explanation
-    /// The anchor point of a [`Rect`] is usually the top-left (x,y).
-    /// When a [`Rect`] is rotated inside a layout, then another corner
-    /// of the [`Rect`] will become the new anchor point after the rotation.
+    /// The anchor point of a [`FloatRect`] is usually the top-left (x,y).
+    /// When a [`FloatRect`] is rotated inside a layout, then another corner
+    /// of the [`FloatRect`] will become the new anchor point after the rotation.
     /// This method returns the current position of that corner.
     pub fn next_anchor(&self, rect: &FloatRect) -> (f32, f32) {
         match self {

--- a/leftwm-layouts/src/geometry/rotation.rs
+++ b/leftwm-layouts/src/geometry/rotation.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::Rect;
+use super::{FloatRect, Rect};
 
 /// Represents the four different possibilities of rotation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -76,12 +76,12 @@ impl Rotation {
     /// When a [`Rect`] is rotated inside a layout, then another corner
     /// of the [`Rect`] will become the new anchor point after the rotation.
     /// This method returns the current position of that corner.
-    pub fn next_anchor(&self, rect: &Rect) -> (i32, i32) {
+    pub fn next_anchor(&self, rect: &FloatRect) -> (f32, f32) {
         match self {
-            Self::North => (rect.x, rect.y),                // top-left
-            Self::East => (rect.x, rect.y + rect.h as i32), // bottom-left
-            Self::South => (rect.x + rect.w as i32, rect.y + rect.h as i32), // bottom-right
-            Self::West => (rect.x + rect.w as i32, rect.y), // top-right
+            Self::North => (rect.x, rect.y),                   // top-left
+            Self::East => (rect.x, rect.y + rect.h),           // bottom-left
+            Self::South => (rect.x + rect.w, rect.y + rect.h), // bottom-right
+            Self::West => (rect.x + rect.w, rect.y),           // top-right
         }
     }
 
@@ -116,7 +116,7 @@ impl Default for Rotation {
 
 #[cfg(test)]
 mod tests {
-    use crate::geometry::Rect;
+    use crate::geometry::{FloatRect, Rect};
 
     use super::Rotation;
 
@@ -161,29 +161,29 @@ mod tests {
 
     #[test]
     fn calc_anchor_north() {
-        let rect = Rect::new(0, 0, 1920, 1080);
+        let rect = FloatRect::new(0.0, 0.0, 1920.0, 1080.0);
         let anchor = Rotation::North.next_anchor(&rect);
-        assert_eq!(anchor, (0, 0));
+        assert_eq!(anchor, (0.0, 0.0));
     }
 
     #[test]
     fn calc_anchor_east() {
-        let rect = Rect::new(0, 0, 1920, 1080);
+        let rect = FloatRect::new(0.0, 0.0, 1920.0, 1080.0);
         let anchor = Rotation::East.next_anchor(&rect);
-        assert_eq!(anchor, (0, 1080));
+        assert_eq!(anchor, (0.0, 1080.0));
     }
 
     #[test]
     fn calc_anchor_south() {
-        let rect = Rect::new(0, 0, 1920, 1080);
+        let rect = FloatRect::new(0.0, 0.0, 1920.0, 1080.0);
         let anchor = Rotation::South.next_anchor(&rect);
-        assert_eq!(anchor, (1920, 1080));
+        assert_eq!(anchor, (1920.0, 1080.0));
     }
 
     #[test]
     fn calc_anchor_west() {
-        let rect = Rect::new(0, 0, 1920, 1080);
+        let rect = FloatRect::new(0.0, 0.0, 1920.0, 1080.0);
         let anchor = Rotation::West.next_anchor(&rect);
-        assert_eq!(anchor, (1920, 0));
+        assert_eq!(anchor, (1920.0, 0.0));
     }
 }


### PR DESCRIPTION
This is a basic implementation of rotating a `Rect` using conversion to floating point numbers and rounding.

A more precise description of the process of rotating an array `rects` goes as follows.
1. Compute `outer_rect`, i.e., the smallest possible `Rect` that contains all the `Rect`s in `rects`.
2. Normalize `rects` such that `outer_rect` can be thought of as the $1 \times 1$ square with anchor at  $(0, 0)$.
3. Rotate the normalized version of `rects` like `translate_rotation` did.
4. Apply the inverse of the normalization and take the integer part of the coordinates.
5. Fill in missing space that got lost by rounding down heights and widths: For each `rect` in `rects`, check whether it is one pixel off from intersecting another element of `rects`. If it is, increase the height and/or width by $1$ accordingly. This works because floating point conversion can introduce a difference of at most $1$. The case where the missing pixels are near the boundary of `outer_rect` needs to be treated separately, but with the same principle.

The main problem I have with my implementation is that I had to introduce a new structure, `FloatRect`, which has very primitive functionality and will probably not have any other use case in its current state. The `next_anchor` method of rotations now use this struct, because I apply it in step 3, which does computations on the normalized `FloatRect`s. I briefly thought about generics for the `Rect` structure, but threw the idea out because there is no such thing as an unsigned float.

It seems to me that using floating point numbers (or an implementation of rational numbers for better precision in case of humongous monitors) are necessary to do step 5 in a legible way.