### PR TITLE
Rotation without Floats

### DIFF
--- a/leftwm-layouts/src/geometry/mod.rs
+++ b/leftwm-layouts/src/geometry/mod.rs
@@ -10,7 +10,6 @@ mod split_axis;
 pub use calc::{divrem, flip, remainderless_division, rotate, split};
 pub use column_type::ColumnType;
 pub use flipped::Flipped;
-use rect::FloatRect;
 pub use rect::Rect;
 pub use reserve_space::ReserveColumnSpace;
 pub use rotation::Rotation;

--- a/leftwm-layouts/src/geometry/rect.rs
+++ b/leftwm-layouts/src/geometry/rect.rs
@@ -69,44 +69,6 @@ impl Default for Rect {
     }
 }
 
-/// Similar to `Rect`, but with less functionality
-///
-/// Intended to perform operations that require rounding afterwards, e.g. rotation.
-pub struct FloatRect {
-    pub x: f32,
-    pub y: f32,
-    pub w: f32,
-    pub h: f32,
-}
-
-impl FloatRect {
-    pub fn new(x: f32, y: f32, w: f32, h: f32) -> Self {
-        Self { x, y, w, h }
-    }
-}
-
-impl From<&Rect> for FloatRect {
-    fn from(rect: &Rect) -> FloatRect {
-        FloatRect {
-            x: rect.x as f32,
-            y: rect.y as f32,
-            w: rect.w as f32,
-            h: rect.h as f32,
-        }
-    }
-}
-
-impl From<&FloatRect> for Rect {
-    fn from(rect: &FloatRect) -> Rect {
-        Rect {
-            x: rect.x as i32,
-            y: rect.y as i32,
-            w: rect.w as u32,
-            h: rect.h as u32,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::Rect;

--- a/leftwm-layouts/src/geometry/rotation.rs
+++ b/leftwm-layouts/src/geometry/rotation.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::{FloatRect, Rect};
+use super::Rect;
 
 /// Represents the four different possibilities of rotation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -72,16 +72,20 @@ impl Rotation {
     /// the Rect's anchor after it is rotated.
     ///
     /// ## Explanation
-    /// The anchor point of a [`FloatRect`] is usually the top-left (x,y).
-    /// When a [`FloatRect`] is rotated inside a layout, then another corner
-    /// of the [`FloatRect`] will become the new anchor point after the rotation.
+    /// The anchor point of a [`Rect`] is usually the top-left (x,y).
+    /// When a [`Rect`] is rotated inside a layout, then another corner
+    /// of the [`Rect`] will become the new anchor point after the rotation.
     /// This method returns the current position of that corner.
-    pub fn next_anchor(&self, rect: &FloatRect) -> (f32, f32) {
+    pub fn next_anchor(&self, rect: &Rect) -> (i32, i32) {
         match self {
-            Self::North => (rect.x, rect.y),                   // top-left
-            Self::East => (rect.x, rect.y + rect.h),           // bottom-left
-            Self::South => (rect.x + rect.w, rect.y + rect.h), // bottom-right
-            Self::West => (rect.x + rect.w, rect.y),           // top-right
+            // top-left
+            Self::North => (rect.x, rect.y),
+            // bottom-left
+            Self::East => (rect.x, rect.y + rect.h as i32),
+            // bottom-right
+            Self::South => (rect.x + rect.w as i32, rect.y + rect.h as i32),
+            // top-right
+            Self::West => (rect.x + rect.w as i32, rect.y),
         }
     }
 
@@ -116,7 +120,7 @@ impl Default for Rotation {
 
 #[cfg(test)]
 mod tests {
-    use crate::geometry::{FloatRect, Rect};
+    use crate::geometry::Rect;
 
     use super::Rotation;
 
@@ -161,29 +165,29 @@ mod tests {
 
     #[test]
     fn calc_anchor_north() {
-        let rect = FloatRect::new(0.0, 0.0, 1920.0, 1080.0);
+        let rect = Rect::new(0, 0, 1920, 1080);
         let anchor = Rotation::North.next_anchor(&rect);
-        assert_eq!(anchor, (0.0, 0.0));
+        assert_eq!(anchor, (0, 0));
     }
 
     #[test]
     fn calc_anchor_east() {
-        let rect = FloatRect::new(0.0, 0.0, 1920.0, 1080.0);
+        let rect = Rect::new(0, 0, 1920, 1080);
         let anchor = Rotation::East.next_anchor(&rect);
-        assert_eq!(anchor, (0.0, 1080.0));
+        assert_eq!(anchor, (0, 1080));
     }
 
     #[test]
     fn calc_anchor_south() {
-        let rect = FloatRect::new(0.0, 0.0, 1920.0, 1080.0);
+        let rect = Rect::new(0, 0, 1920, 1080);
         let anchor = Rotation::South.next_anchor(&rect);
-        assert_eq!(anchor, (1920.0, 1080.0));
+        assert_eq!(anchor, (1920, 1080));
     }
 
     #[test]
     fn calc_anchor_west() {
-        let rect = FloatRect::new(0.0, 0.0, 1920.0, 1080.0);
+        let rect = Rect::new(0, 0, 1920, 1080);
         let anchor = Rotation::West.next_anchor(&rect);
-        assert_eq!(anchor, (1920.0, 0.0));
+        assert_eq!(anchor, (1920, 0));
     }
 }


### PR DESCRIPTION
Because the conversion of aspect ratios involves only a single division, doing the arithmetic in the correct order directly on the `i32`s results in the same number. Using this observation, I was able to get rid of floats and all the trash (`FloatRect`) that came with it.